### PR TITLE
Update obsolete collection.save()

### DIFF
--- a/mongodb.js
+++ b/mongodb.js
@@ -120,7 +120,7 @@ module.exports = function(RED) {
                                 });
                             }
                             else {
-                                coll.save(msg,function(err, item) {
+                                coll.insertOne(msg,function(err, item) {
                                     if (err) { 
                                         node.error(err, msg); 
                                         return;


### PR DESCRIPTION
Starting in MongoDB 4.2, the 
db.collection.save()
 method is deprecated. Use db.collection.insertOne() or db.collection.replaceOne() instead.